### PR TITLE
fix: resolve leaderboard failing to load

### DIFF
--- a/src/hooks/useGetLeaderboard.js
+++ b/src/hooks/useGetLeaderboard.js
@@ -24,7 +24,7 @@ const useGetLeaderboard = () => {
         const res = await fetch(`${API_BASE}/v1/leaderboard${userIdParam}`, {
           method: "GET",
           headers: {
-            Authorization: `Bearer ${token}`,
+            ...(token && { Authorization: `Bearer ${token}` }),
           },
         });
         if (!res.ok) {
@@ -51,14 +51,14 @@ const useGetLeaderboard = () => {
         setIsLoading(false);
       }
     },
-    [leaderboard, currentUser],
+    [leaderboard, currentUser, getToken],
   );
 
   useEffect(() => {
     if (isLoaded) {
       getLeaderboard();
     }
-  }, [isLoaded]);
+  }, [isLoaded, getLeaderboard]);
 
   return {
     isLoading,

--- a/src/sections/Leaderboard.jsx
+++ b/src/sections/Leaderboard.jsx
@@ -7,10 +7,9 @@ import {
   TableBody,
   TableRow,
   TableCell,
+  Input,
+  Pagination,
 } from "@nextui-org/react";
-import { useUser, useAuth } from "@clerk/clerk-react";
-import { Input } from "@nextui-org/react";
-import { Pagination } from "@nextui-org/react";
 
 const Leaderboard = ({ leaderboard }) => {
   const [filterValue, setFilterValue] = useState("");
@@ -21,8 +20,6 @@ const Leaderboard = ({ leaderboard }) => {
   });
   const [page, setPage] = useState(1);
 
-  const { user: currentUser, isLoaded } = useUser();
-  const { getToken } = useAuth();
   const [rankedUsers, setRankedUsers] = useState(leaderboard ?? []);
 
   const onSearchChange = useCallback((value) => {
@@ -35,36 +32,12 @@ const Leaderboard = ({ leaderboard }) => {
     setPage(1);
   }, []);
 
-  // Fetch leaderboard with userId
+  // Sync rankedUsers when leaderboard prop changes
   useEffect(() => {
-    if (!isLoaded) return;
-    if (leaderboard && leaderboard.length > 0) {
+    if (leaderboard) {
       setRankedUsers(leaderboard);
-      return;
     }
-    const fetchLeaderboard = async () => {
-      try {
-        const token = await getToken();
-        const userIdParam = currentUser?.id ? `?userId=${currentUser.id}` : "";
-        const res = await fetch(
-          `https://api.ggithubstreak.com/v1/leaderboard${userIdParam}`,
-          {
-            method: "GET",
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
-        const data = await res.json();
-        if (Array.isArray(data)) {
-          setRankedUsers(data);
-        }
-      } catch (err) {
-        // Optionally handle error
-      }
-    };
-    fetchLeaderboard();
-  }, [isLoaded, currentUser, leaderboard]);
+  }, [leaderboard]);
 
   // Filter users
   const filteredUsers = useMemo(() => {
@@ -289,15 +262,17 @@ const Leaderboard = ({ leaderboard }) => {
                 sortedUsers.length
               } developers`}
         </span>
-        <Pagination
-          isCompact
-          showControls
-          showShadow
-          color="primary"
-          page={page}
-          total={pages}
-          onChange={setPage}
-        />
+        {pages > 0 && (
+          <Pagination
+            isCompact
+            showControls
+            showShadow
+            color="primary"
+            page={page}
+            total={pages}
+            onChange={setPage}
+          />
+        )}
         <div className="hidden sm:flex w-[30%] justify-end gap-2">
           <span className="text-small text-default-400">Rows per page:</span>
           <select


### PR DESCRIPTION
## Summary

- Fix stale closure bugs in `useGetLeaderboard` by adding `getToken` and `getLeaderboard` to their missing dependency arrays
- Only send `Authorization` header when a valid token exists, preventing `Bearer null` being sent for unauthenticated users
- Remove duplicate internal fetch from `Leaderboard` component that used a hardcoded production URL, raw untransformed data, and silently swallowed errors
- Simplify `Leaderboard` `useEffect` to only sync `rankedUsers` from the prop
- Remove unused `useUser`/`useAuth` Clerk imports from `Leaderboard` component
- Guard `<Pagination>` from rendering with `total={0}` when search filters out all results (prevented a potential crash)

## Test plan

- [ ] Visit `/dashboard` as a signed-in user and confirm the leaderboard loads correctly
- [ ] Visit `/dashboard` as a signed-out user and confirm no `Bearer null` auth error occurs
- [ ] Search for a username that has no matches and confirm no crash occurs (pagination hides gracefully)
- [ ] Click "Try Again" on the error UI and confirm it refetches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)